### PR TITLE
type check

### DIFF
--- a/mtz-marked-editor.html
+++ b/mtz-marked-editor.html
@@ -62,7 +62,10 @@ Creates a textarea with common editor logic and can be controlled by UI elements
        * @return {String}
        */
       getContent() {
-        return this.getTextarea().value;
+        if (typeof this.getTextarea() !== typeof undefined) {
+          return this.getTextarea().value;
+        }
+        return '';
       },
       /**
        * Sets the content of the textarea


### PR DESCRIPTION
minor type check error when textarea is not yet defined or if there is no content in that area. Has been hard for me to replicate but easy enough to trap to ensure it doesn't throw an error when really it anything calls this it should just return empty.